### PR TITLE
Added automated Windows builds via Appveyor.

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,37 @@
+version: Build {build}
+
+skip_non_tags: true
+
+build:
+    verbosity: minimal
+
+environment:
+    matrix:
+        - PYTHON: "C:\\Python35"
+
+install:
+    - "SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%"
+    - "pip install -r requirements.txt"
+    - "pip install pyinstaller"
+
+build_script:
+    - "pyinstaller setup.spec"
+
+after_build:
+    - "cp README.md dist"
+    - "cd dist && 7z a peld_%APPVEYOR_REPO_TAG_NAME%.zip . -tzip -mx=7"
+
+artifacts:
+    - path: dist\peld_$(APPVEYOR_REPO_TAG_NAME).zip
+      name: peld
+
+deploy:
+    - provider: GitHub
+      description: ""
+      artifact: peld
+      draft: false
+      prerelease: false
+      on:
+        appveyor_repo_tag: true
+      auth_token:
+        secure: nJm0eDjrcfLhUCTsM7AiTp7GJi40mWXB8LPFRHek/uMqcvX2mdxxZ8cusuns5GAO


### PR DESCRIPTION
This pull requests adds automated Windows builds of PELD via AppVeyor.  The result is automatically packaged and uploaded to GitHub Releases with each tagged commit.

## Why?

Automatic builds are awesome.  No need to waste your own time or bandwidth, and no getting stuck when The One Who Can Build goes missing or breaks their local config.  This frees up development time and makes collaboration easier.

AppVeyor was chosen because `pyinstaller` requires an actual Windows environment when freezing for Windows, but popular alternatives like Travis CI only offer Mac or Linux.  Luckily, AppVeyor has similar syntax to Travis CI and is free for open source projects.

## How to use?

AppVeyor is configured via the `appveyor.yml` file.  Currently, it automatically builds on tag and pushes the zipped executable and README back to GitHub Releases.

Whenever it's time for a new release, simply push a tag so AppVeyor takes notice.  This is already being done with PELD, so no change in workflow is required (except not manually building and uploading).

Edit the release on GitHub afterwards to add patch notes, if applicable.  Else the release description may default to a blank message or the latest commit message.

## What's left to do?

Automatic builds need to be enabled at AppVeyor and the `auth_token` needs to be set from a GitHub account with write access to the repo.

### Configuring AppVeyor

1. [Log in at AppVeyor](https://ci.appveyor.com) using your GitHub credentials.
2. Click `(+) New Project` in the top left, then `GitHub` > `Authorize GitHub` for public projects.
3. Back in AppVeyor, mouse over `PyEveLiveDps` and click `(+) Add` on the far right.

### Configuring `auth_token`

1. [Log in at AppVeyor](https://ci.appveyor.com) using your GitHub credentials.
2. On GitHub, [generate a new access token](https://github.com/settings/tokens):
    1. Click `Generate new token` in the top right.
    2. Name it `AppVeyor` and check `public_repo`.
    3. Copy the resulting token somewhere safe.
3. On AppVeyor, [encrypt the token](https://ci.appveyor.com/tools/encrypt) for safe use in the config file:
    1. Paste the previously generated token and click `Encrypt`.
    2. In `appveyor.yml`, set `auth_token: secure:` to the encrypted token from last step.  *DO NOT* use the unencrypted token here or bad things can happen to your repos!
    3. Commit and tag the change containing the updated auth token, then push.

From here on, AppVeyor will autonomously process each tagged commit without further intervention.