### PR TITLE
Rename deprecated method

### DIFF
--- a/PyEveLiveDPS/graph.py
+++ b/PyEveLiveDPS/graph.py
@@ -43,7 +43,7 @@ class DPSGraph(tk.Frame):
         self.canvas.get_tk_widget().configure(bg="black")
         self.canvas.get_tk_widget().pack(side=tk.BOTTOM, fill=tk.BOTH, expand=True)
         
-        self.canvas.show()
+        self.canvas.draw()
         
     def readjust(self, highestAverage):
         """


### PR DESCRIPTION
The "show" method on this class has been deprecated, the "draw" method replaced it. This will allow PyEveLiveDPS to run on newer versions of TKinter.